### PR TITLE
fix java.lang.IllegalStateException

### DIFF
--- a/library/src/main/java/com/wuman/android/auth/DialogFragmentCompat.java
+++ b/library/src/main/java/com/wuman/android/auth/DialogFragmentCompat.java
@@ -72,6 +72,14 @@ class DialogFragmentCompat extends FragmentCompat {
         }
     }
 
+    final void dismissAllowingStateLoss() {
+        if (supportDialogFragment != null) {
+            supportDialogFragment.dismissAllowingStateLoss();
+        } else {
+            nativeDialogFragment.dismissAllowingStateLoss();
+        }
+    }
+
     final Dialog getDialog() {
         if (supportDialogFragment != null) {
            return supportDialogFragment.getDialog();

--- a/library/src/main/java/com/wuman/android/auth/DialogFragmentController.java
+++ b/library/src/main/java/com/wuman/android/auth/DialogFragmentController.java
@@ -170,7 +170,7 @@ public abstract class DialogFragmentController implements AuthorizationDialogCon
                 DialogFragmentCompat frag = fragmentManager
                         .findFragmentByTag(DialogFragmentCompat.class, FRAGMENT_TAG);
                 if (frag != null) {
-                    frag.dismiss();
+                    frag.dismissAllowingStateLoss();
                 }
             }
         });


### PR DESCRIPTION
fix java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState: use dismissAllowingStateLoss since we don't need to keep the states.
