### PR TITLE
make AuthorizationFlow.setRequestInitializer() work

### DIFF
--- a/library/src/main/java/com/wuman/android/auth/AuthorizationFlow.java
+++ b/library/src/main/java/com/wuman/android/auth/AuthorizationFlow.java
@@ -221,12 +221,12 @@ public class AuthorizationFlow extends AuthorizationCodeFlow {
         return new LenientAuthorizationCodeTokenRequest(getTransport(), getJsonFactory(),
                 new GenericUrl(getTokenServerEncodedUrl()), authorizationCode)
                 .setClientAuthentication(getClientAuthentication())
-                .setRequestInitializer(getRequestInitializer())
                 .setScopes(getScopes())
                 .setRequestInitializer(
                         new HttpRequestInitializer() {
                             @Override
                             public void initialize(HttpRequest request) throws IOException {
+                                getRequestInitializer().initialize(request);
                                 request.getHeaders().setAccept("application/json");
                             }
                         });


### PR DESCRIPTION
Hi,

I noticed that while `AuthorizationFlow.Builder` has a `setRequestInitializer` method, that initializer's `initialize` method was never called.

This PR fixes this problem:

while `AuthorizationFlow.newTokenRequest()`  tried to set the request initializer on `LenientAuthorizationCodeTokenRequest`, this was immediately undone later as the method was providing its own initializer to set the `Accept` header.

`AuthorizationCodeTokenRequest` only supports one request initializer, so the second call has overriden the first, never executing the custom request initializer