### PR TITLE
Add a new interface method to AuthorizationDialogController to enable WebView DOM storage APIs

### DIFF
--- a/library/src/main/java/com/wuman/android/auth/AuthorizationDialogController.java
+++ b/library/src/main/java/com/wuman/android/auth/AuthorizationDialogController.java
@@ -92,5 +92,12 @@ public interface AuthorizationDialogController extends AuthorizationUIController
      *         otherwise.
      */
     boolean removePreviousCookie();
-
+	
+	/**
+     * Indicate whether DOM storage (localStorage) should be enabled for the WebView.
+     * 
+     * @return {@code true} if DOM storage should be enabled, {@code false}
+     *         otherwise.
+     */
+    boolean isDomStorageEnabledForWebView();
 }

--- a/library/src/main/java/com/wuman/android/auth/AuthorizationDialogController.java
+++ b/library/src/main/java/com/wuman/android/auth/AuthorizationDialogController.java
@@ -92,8 +92,8 @@ public interface AuthorizationDialogController extends AuthorizationUIController
      *         otherwise.
      */
     boolean removePreviousCookie();
-	
-	/**
+
+    /**
      * Indicate whether DOM storage (localStorage) should be enabled for the WebView.
      * 
      * @return {@code true} if DOM storage should be enabled, {@code false}

--- a/library/src/main/java/com/wuman/android/auth/OAuthDialogFragment.java
+++ b/library/src/main/java/com/wuman/android/auth/OAuthDialogFragment.java
@@ -287,9 +287,9 @@ class OAuthDialogFragment extends DialogFragmentCompat {
             webSettings.setJavaScriptEnabled(true);
         }
 		
-		if (mController.isDomStorageEnabledForWebView()) {
-			webSettings.setDomStorageEnabled(true);
-		}
+        if (mController.isDomStorageEnabledForWebView()) {
+            webSettings.setDomStorageEnabled(true);
+        }
 
         if (mController.disableWebViewCache()) {
             webSettings.setAppCacheEnabled(false);

--- a/library/src/main/java/com/wuman/android/auth/OAuthDialogFragment.java
+++ b/library/src/main/java/com/wuman/android/auth/OAuthDialogFragment.java
@@ -286,6 +286,10 @@ class OAuthDialogFragment extends DialogFragmentCompat {
         if (mController.isJavascriptEnabledForWebView()) {
             webSettings.setJavaScriptEnabled(true);
         }
+		
+		if (mController.isDomStorageEnabledForWebView()) {
+			webSettings.setDomStorageEnabled(true);
+		}
 
         if (mController.disableWebViewCache()) {
             webSettings.setAppCacheEnabled(false);

--- a/samples/src/main/java/com/wuman/oauth/samples/CustomizedProgressActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/CustomizedProgressActivity.java
@@ -351,10 +351,10 @@ public class CustomizedProgressActivity extends FragmentActivity {
             return false;
         }
 
-		@Override
-		public boolean isDomStorageEnabledForWebView() {
-			return true;
-		}
+        @Override
+        public boolean isDomStorageEnabledForWebView() {
+            return true;
+        }
     }
 
 }

--- a/samples/src/main/java/com/wuman/oauth/samples/CustomizedProgressActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/CustomizedProgressActivity.java
@@ -351,6 +351,10 @@ public class CustomizedProgressActivity extends FragmentActivity {
             return false;
         }
 
+		@Override
+		public boolean isDomStorageEnabledForWebView() {
+			return true;
+		}
     }
 
 }

--- a/samples/src/main/java/com/wuman/oauth/samples/OAuth.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/OAuth.java
@@ -98,7 +98,11 @@ public class OAuth {
                     public boolean removePreviousCookie() {
                         return false;
                     }
-
+					
+					@Override
+					public boolean isDomStorageEnabledForWebView() {
+						return true;
+					}
                 };
         return new OAuth(flow, controller);
     }

--- a/samples/src/main/java/com/wuman/oauth/samples/OAuth.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/OAuth.java
@@ -98,11 +98,11 @@ public class OAuth {
                     public boolean removePreviousCookie() {
                         return false;
                     }
-					
-					@Override
-					public boolean isDomStorageEnabledForWebView() {
-						return true;
-					}
+
+                    @Override
+                    public boolean isDomStorageEnabledForWebView() {
+                        return true;
+                    }
                 };
         return new OAuth(flow, controller);
     }

--- a/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ExplicitActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ExplicitActivity.java
@@ -185,6 +185,10 @@ public class SimpleOAuth2ExplicitActivity extends FragmentActivity {
                             return false;
                         }
 
+						@Override
+						public boolean isDomStorageEnabledForWebView() {
+							return true;
+						}
                     };
             // instantiate an OAuthManager instance
             oauth = new OAuthManager(flow, controller);

--- a/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ExplicitActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ExplicitActivity.java
@@ -185,10 +185,10 @@ public class SimpleOAuth2ExplicitActivity extends FragmentActivity {
                             return false;
                         }
 
-						@Override
-						public boolean isDomStorageEnabledForWebView() {
-							return true;
-						}
+                        @Override
+                        public boolean isDomStorageEnabledForWebView() {
+                            return true;
+                        }
                     };
             // instantiate an OAuthManager instance
             oauth = new OAuthManager(flow, controller);

--- a/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ImplicitActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ImplicitActivity.java
@@ -184,10 +184,10 @@ public class SimpleOAuth2ImplicitActivity extends FragmentActivity {
                             return false;
                         }
 						
-						@Override
-						public boolean isDomStorageEnabledForWebView() {
-							return true;
-						}
+                        @Override
+                        public boolean isDomStorageEnabledForWebView() {
+                                return true;
+                        }
 
                     };
             // instantiate an OAuthManager instance

--- a/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ImplicitActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ImplicitActivity.java
@@ -183,6 +183,11 @@ public class SimpleOAuth2ImplicitActivity extends FragmentActivity {
                         public boolean removePreviousCookie() {
                             return false;
                         }
+						
+						@Override
+						public boolean isDomStorageEnabledForWebView() {
+							return true;
+						}
 
                     };
             // instantiate an OAuthManager instance

--- a/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ImplicitActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/foursquare/SimpleOAuth2ImplicitActivity.java
@@ -186,7 +186,7 @@ public class SimpleOAuth2ImplicitActivity extends FragmentActivity {
 						
                         @Override
                         public boolean isDomStorageEnabledForWebView() {
-                                return true;
+                            return true;
                         }
 
                     };

--- a/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth10aActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth10aActivity.java
@@ -187,6 +187,10 @@ public class SimpleOAuth10aActivity extends FragmentActivity {
                             return false;
                         }
 
+						@Override
+						public boolean isDomStorageEnabledForWebView() {
+							return true;
+						}
                     };
             // instantiate an OAuthManager instance
             oauth10a = new OAuthManager(flow, controller);

--- a/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth10aActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth10aActivity.java
@@ -187,10 +187,10 @@ public class SimpleOAuth10aActivity extends FragmentActivity {
                             return false;
                         }
 
-						@Override
-						public boolean isDomStorageEnabledForWebView() {
-							return true;
-						}
+                        @Override
+                        public boolean isDomStorageEnabledForWebView() {
+                            return true;
+                        }
                     };
             // instantiate an OAuthManager instance
             oauth10a = new OAuthManager(flow, controller);

--- a/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth2ExplicitActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth2ExplicitActivity.java
@@ -186,10 +186,10 @@ public class SimpleOAuth2ExplicitActivity extends FragmentActivity {
                             return false;
                         }
 
-						@Override
-						public boolean isDomStorageEnabledForWebView() {
-							return true;
-						}
+                        @Override
+                        public boolean isDomStorageEnabledForWebView() {
+                            return true;
+                        }
                     };
             // instantiate an OAuthManager instance
             oauth = new OAuthManager(flow, controller);

--- a/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth2ExplicitActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/linkedin/SimpleOAuth2ExplicitActivity.java
@@ -186,6 +186,10 @@ public class SimpleOAuth2ExplicitActivity extends FragmentActivity {
                             return false;
                         }
 
+						@Override
+						public boolean isDomStorageEnabledForWebView() {
+							return true;
+						}
                     };
             // instantiate an OAuthManager instance
             oauth = new OAuthManager(flow, controller);

--- a/samples/src/main/java/com/wuman/oauth/samples/strava/StravaActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/strava/StravaActivity.java
@@ -193,10 +193,10 @@ public class StravaActivity extends FragmentActivity {
                             return false;
                         }
 
-						@Override
-						public boolean isDomStorageEnabledForWebView() {
-							return true;
-						}
+                        @Override
+                        public boolean isDomStorageEnabledForWebView() {
+                            return true;
+                        }
                     };
             // instantiate an OAuthManager instance
             oauth = new OAuthManager(flow, controller);

--- a/samples/src/main/java/com/wuman/oauth/samples/strava/StravaActivity.java
+++ b/samples/src/main/java/com/wuman/oauth/samples/strava/StravaActivity.java
@@ -193,6 +193,10 @@ public class StravaActivity extends FragmentActivity {
                             return false;
                         }
 
+						@Override
+						public boolean isDomStorageEnabledForWebView() {
+							return true;
+						}
                     };
             // instantiate an OAuthManager instance
             oauth = new OAuthManager(flow, controller);


### PR DESCRIPTION
Some OAuth services want to use the WebView's localStorage to store data and if the [WebSettings.setDomStorageEnabled](https://developer.android.com/reference/android/webkit/WebSettings.html#setDomStorageEnabled(boolean)) is not set to true, the global `localStorage` variable will be null in the `WebView`. This method enables custom authorization controllers implementing this interface to set the option to true/false.